### PR TITLE
fix multiple active pages in navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -22,7 +22,7 @@ function Navbar() {
 			</div>
 			<div className='icons'>
 				<NavLink
-					to={'/'}
+					to={'/'} end
 					className={({isActive}) => (isActive ? 'isActive' : null)}>
 					<IoHome />
 				</NavLink>


### PR DESCRIPTION
closes #1 

This PR fixes the multiple active pages bug in the navbar.
The bug happened because all routes starts with a slash, so the main root `"/"` was always "active". 
You can find more about it [here](https://reactrouter.com/en/main/components/nav-link)!